### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4==4.7.1
+requests==2.21.0
+requests-oauthlib==1.3.0
+selenium==3.141.0
+tweepy==3.8.0


### PR DESCRIPTION
When I first tried this I had the same issue as #9 

I think creating a requirements.txt file with the exact version requirements for each module would be helpful for others, so they can easily start with `pip install -r requirements.txt`